### PR TITLE
We need to build client code before deploying

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: deploy
+on: 
+  push:
+    branches:
+    - main
+  workflow_dispatch:
+          
+jobs:
+  # Build job
+  build:
+    name: Build frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - name: setup repo
+        run: npm install
+      - name: Build react
+        run: npm run build
+      - name: collect depoloyment files
+        run: |
+          mkdir _site
+          mkdir _site/dist
+          cp dist/* _site/dist/
+          cp *.html _site/
+      - uses: actions/upload-pages-artifact@v1
+
+  # Deploy job
+  deploy:
+    # Add a dependency to the build job
+    needs: build
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
Now that we support react on our frontend, we need to support a more flexible deploy process. This PR introduces a github action that will build the frontend before deploying to github pages. 